### PR TITLE
Support running etcd in a lxc container

### DIFF
--- a/playbooks/facts.yml
+++ b/playbooks/facts.yml
@@ -39,3 +39,15 @@
       setup:
         gather_subset: '!all,!min,hardware'
         filter: "ansible_*total_mb"
+
+- name: Detect virtualization type
+  hosts: all
+  tasks:
+    - name: Run systemd-detect-virt
+      command: systemd-detect-virt
+      register: virt_result
+      ignore_errors: yes  # Optional: ignores errors if the command fails
+
+    - name: Set ansible_virtualization_type variable
+      set_fact:
+        ansible_virtualization_type: "{{ virt_result.stdout }}"

--- a/roles/etcdctl_etcdutl/tasks/main.yml
+++ b/roles/etcdctl_etcdutl/tasks/main.yml
@@ -25,6 +25,7 @@
     src: "{{ downloads.etcd.dest }}"
     dest: "{{ local_release_dir }}/"
     remote_src: true
+    unarchive_extra_opts: "{{ ['--no-same-owner'] if ansible_virtualization_type == 'lxc' else [] }}"
   when: container_manager in ['crio', 'containerd']
 
 - name: Copy etcdctl and etcdutl binary from download dir

--- a/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
+++ b/roles/kubernetes/preinstall/tasks/0010-swapoff.yml
@@ -24,3 +24,5 @@
 
 - name: Disable swap
   command: /sbin/swapoff -a
+  when:
+    - ansible_virtualization_type != "lxc"

--- a/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
+++ b/roles/kubernetes/preinstall/tasks/0080-system-configurations.yml
@@ -118,14 +118,18 @@
     - { name: kernel.panic_on_oops, value: 1 }
     - { name: vm.overcommit_memory, value: 1 }
     - { name: vm.panic_on_oom, value: 0 }
-  when: kubelet_protect_kernel_defaults | bool
+  when:
+    - kubelet_protect_kernel_defaults | bool
+    - ansible_virtualization_type != "lxc"
 
 - name: Check dummy module
   community.general.modprobe:
     name: dummy
     state: present
     params: 'numdummies=0'
-  when: enable_nodelocaldns
+  when:
+    - enable_nodelocaldns
+    - ansible_virtualization_type != "lxc"
 
 - name: Set additional sysctl variables
   ansible.posix.sysctl:

--- a/roles/kubespray-defaults/defaults/main/download.yml
+++ b/roles/kubespray-defaults/defaults/main/download.yml
@@ -450,6 +450,7 @@ downloads:
       else etcd_digest_checksum | d(None) }}
     url: "{{ etcd_download_url }}"
     unarchive: "{{ etcd_deployment_type == 'host' }}"
+    unarchive_extra_opts: "{{ ['--no-same-owner'] if ansible_virtualization_type == 'lxc' else [] }}"
     owner: "root"
     mode: "0755"
     groups:


### PR DESCRIPTION
In a test lab environment with limited resources, one can save some resources
if you run etcds in LXC containers. 

Using an LXC container causes kubespray to fail, as it assumes that etcds run
on a (virtual) machine. It tries setting swap, and an LXC container does not
allow to chown the etcd binary in the standard setting.

This patch introduces the ansible_virtualization_type variable, similar to
running normal ansible, which allows you to determine if you run in a LXC
container or else.

Then, it makes the necessary adjustments to solve the above issues for an LXC
container.